### PR TITLE
upgrade laravel-support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "illuminate/console": "^8.0.0 || ^9.0.0 || ^10.0.0",
         "illuminate/database": "^8.0.0 || ^9.0.0 || ^10.0.0",
         "illuminate/support": "^8.0.0 || ^9.0.0 || ^10.0.0",
-        "rinvex/laravel-support": "^5.0.0 || ^6.0.0",
+        "rinvex/laravel-support": "^7.0.1",
         "spatie/eloquent-sortable": "^4.0.0",
         "spatie/laravel-sluggable": "^3.3.0",
         "spatie/laravel-translatable": "^5.2.0"


### PR DESCRIPTION
the Author of  `rinvex/laravel-support` has dropped the incompatible package `felixkiss/uniquewith-validator` which I merged earlier in my fork and  said its no longer required and can be added to project level if needed
please check this commit 
https://github.com/rinvex/laravel-support/commit/eec503152034b428167f0d6cb9d6b7bda45ac028

I wish he did this earlier and save me the time of merging the package :D 

as such ,we don`t need this fork 
https://github.com/zidsa/laravel-support/