### PR TITLE
downgrade laravel-support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "illuminate/console": "^8.0.0 || ^9.0.0 || ^10.0.0",
         "illuminate/database": "^8.0.0 || ^9.0.0 || ^10.0.0",
         "illuminate/support": "^8.0.0 || ^9.0.0 || ^10.0.0",
-        "rinvex/laravel-support": "^7.0.1",
+        "rinvex/laravel-support": "v6.1.4",
         "spatie/eloquent-sortable": "^4.0.0",
         "spatie/laravel-sluggable": "^3.3.0",
         "spatie/laravel-translatable": "^5.2.0"


### PR DESCRIPTION
we need to merge [this](https://github.com/zidsa/laravel-support/pull/1) first , then we can update the repositories in `composer.json` in our l9 upgrade branch to use zidsa repositories 

