### PR TITLE
Save 20 thousand queries with one line of code

### DIFF
--- a/src/Traits/HasSubscriptions.php
+++ b/src/Traits/HasSubscriptions.php
@@ -100,9 +100,12 @@ trait HasSubscriptions
         $trial = new Period($plan->trial_interval, $plan->trial_period - 1 , $startDate ?? now());
         $period = new Period($plan->invoice_interval, $plan->invoice_period - 1, $trial->getEndDate());
 
+        $uuid = Uuid::uuid4()->toString();
+
         return $this->subscriptions()->create([
             'name' => $subscription,
-            'uuid' => Uuid::uuid4()->toString(),
+            'uuid' => $uuid,
+            'slug' => $uuid,
             'store_uuid' => $storeUUid,
             'plan_id' => $plan->getKey(),
             'app_id' => $plan->getAppId(),


### PR DESCRIPTION
The more specific title would be: spent 5h debugging and prevent 20k queries to fix the performance of `AppMarketSubscriptionListener` which takes 30s+ on production.

(scroll below to skip all the blabbering and jump to tech details)

## Write-up

A few months ago I was asked to look into the problems with `AppMarketSubscriptionListener` and why sometimes the subscriptions are not created for merchants upon paying for the ZAM app plans. From the start we suspected the problem might be with the performance of event listeners for the `PurchaseApprovedEvent` and we started checking all of the preceding listeners to confirm it. Unfortunately, there's quite a few:

```php
PurchaseApprovedEvent::class => [
    SendPurchaseInvoiceListener::class,
    ZidShipBalancePurchasedListener::class,
    ZidShipPackagePurchasedListener::class,
    CreatePosCashierSubscriptionListener::class,
    // PurchaseListener::class,
    ProcessCorePackagesPurchase::class,
    ThemesPurchasedListener::class,
    PartnerThemesPurchaseListener::class,
    SmsCampaignPurchaseListener::class,
    OrderNotificationPurchaseListener::class,
    MobileAppPurchasedListener::class,
    SenderIdPurchasedListener::class,
    SubscriptionPurchaseXeroListener::class,
    WickedReportsPurchaseListener::class,
    RegisterViralLoopsParticipant::class,
    LinkarabyPurchaseListener::class,
    // Here's the listener that sometimes didn't run on production. Unfortunately not all
    // listeners before it are queued
    AppMarketSubscriptionListener::class,
    GenerateStoreDefaultPosPaymentMethodsListener::class,
    CreateOdooAddonsOnPurchase::class,
    PosCreateStoreOwnerCashierUserListener::class,
    HandleWalletListener::class,
    HandleAddonPurchase::class,
],
```

Eventually I wrote a following code snippet to assist with processing individual purchases where the listener didn't run:

```php
// RUN ON THE exporter pod!

$purchase = \App\Models\Domain\Purchases\Purchase::findOrFail('07545aac-cb92-4ab7-ab4b-98656f6ae9cb');

$event = new \Zid\Purchases\Application\Event\PurchaseApprovedEvent(
    \Ramsey\Uuid\Uuid::fromString($purchase->id),
    \Ramsey\Uuid\Uuid::fromString($purchase->store_id),
    $purchase->meta['is_recurring'],
);

$listener = app()->make(\Zid\Modules\AppMarket\Purchase\Listeners\AppMarketSubscriptionListener::class);

\DB::transaction(function () use ($listener, $event) {
    $listener->handle($event);
});
```

What immediately caught my attention is that running the actual listener method on production via tinker used to take more than 15 seconds, often even more than 30.

---

Tonight, after writing a shitton of code to seed all of the ZAM models involved in the process, I managed to run the listener locally. The problem was, there weren't many queries at all! I did find one place where we did `4n + 1` but the `n` in most cases would be around 2-10 which is not the end of the world at all.

However, once I ran the debug commands on the testing environment, I quickly noticed lots of repetitive queries:

![image](https://github.com/zidsa/laravel-subscriptions/assets/1347533/a1a5e47d-4d96-4577-af75-c69755c2f118)

It took me ages to understand why the seemingly innocent `$this->subscriptions()->create(...)` line was causing over 20 queries on the testing env (and it didn't cause any problems on local). Thankfully Amr Gamal (@viscod) joined me at this step to help with rubber duck debugging and prove that it's not a problem with the relation of choice (`morphMany()`).

Eventually I realized what the problem was, which you can find in not as boring section below... 

## Technical summary

1. When we create new subscriptions, we set their name to `main` (e.g. in `PlanSubscriptionService::renewSubscription()`)
2. This calls `$this->subscriptions()->create(...)` (where `$this` refers to the `Store` model in case of our project)
3. The `subscriptions()` relation refers to the `AppMarketPlanSubscription` model which, among other things, uses the `HasSlug` trait from the `spatie/laravel-sluggable` package
4. Eventually the package calls the following method:

```php
    protected function makeSlugUnique(string $slug): string
    {
        $originalSlug = $slug;
        $i = $this->slugOptions->startSlugSuffixFrom;

        while ($this->otherRecordExistsWithSlug($slug) || $slug === '') {
            $slug = $originalSlug.$this->slugOptions->slugSeparator.$i++;
        }

        return $slug;
    }
```

which walks the whole table trying to find the first non-colliding row to know the increment counter it has to use for the slug (`main-X`).

Normally, this wouldn't be such a problem but our `app_market_plan_subscriptions` table has over 20 thousand rows on production and all of them use the same name, hence the same slug prefix.


Assigning an explicit slug skips all of the code related to finding the unique slug. End of story.