### PR TITLE
add usage based columns to app market plans

### DIFF
--- a/database/migrations/2025_01_19_113021_add_usage_based_columns_to_app_market_plans_table.php
+++ b/database/migrations/2025_01_19_113021_add_usage_based_columns_to_app_market_plans_table.php
@@ -11,5 +11,8 @@ return new class extends Migration {
             $table->boolean('is_usage_based')->default(false);
             $table->json('meta')->nullable();
         });
+        Schema::table(config('rinvex.subscriptions.tables.app_market_plan_subscriptions'), function (Blueprint $table) {
+            $table->boolean('is_usage_based')->default(false);
+        });
     }
 };

--- a/database/migrations/2025_01_19_113021_add_usage_based_columns_to_app_market_plans_table.php
+++ b/database/migrations/2025_01_19_113021_add_usage_based_columns_to_app_market_plans_table.php
@@ -1,0 +1,15 @@
+<?php
+
+use App\Foundation\Database\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table(config('rinvex.subscriptions.tables.app_market_plans'), function (Blueprint $table) {
+            $table->boolean('is_usage_based')->default(false);
+            $table->json('meta')->nullable();
+        });
+    }
+};

--- a/src/Models/AppMarketPlan.php
+++ b/src/Models/AppMarketPlan.php
@@ -108,6 +108,8 @@ class AppMarketPlan extends Model implements Sortable
         'prorate_extend_due',
         'active_subscribers_limit',
         'sort_order',
+        'is_usage_based',
+        'meta',
     ];
 
     /**
@@ -135,6 +137,8 @@ class AppMarketPlan extends Model implements Sortable
         'active_subscribers_limit' => 'integer',
         'sort_order' => 'integer',
         'deleted_at' => 'datetime',
+        'is_usage_based' => 'boolean',
+        'meta' => 'array',
     ];
 
     /**

--- a/src/Models/AppMarketPlanSubscription.php
+++ b/src/Models/AppMarketPlanSubscription.php
@@ -97,6 +97,7 @@ class AppMarketPlanSubscription extends Model
         'ends_at',
         'cancels_at',
         'canceled_at',
+        'is_usage_based',
     ];
 
     /**

--- a/src/Traits/HasSubscriptions.php
+++ b/src/Traits/HasSubscriptions.php
@@ -95,8 +95,20 @@ trait HasSubscriptions
      *
      * @return \Rinvex\Subscriptions\Models\AppMarketPlanSubscription
      */
-    public function newSubscription($purchaseId, $storeUUid, $subscription, AppMarketPlan $plan, Carbon $startDate = null, $status, $isRecurring = false, $remainingDays = 0, $tax_percentage = 0.15, ?float $amountLeft = null, ?float $amountLeftWithoutTax = null): AppMarketPlanSubscription
-    {
+    public function newSubscription(
+        $purchaseId,
+        $storeUUid,
+        $subscription,
+        AppMarketPlan $plan,
+        Carbon $startDate = null,
+        $status,
+        $isRecurring = false,
+        $remainingDays = 0,
+        $tax_percentage = 0.15,
+        ?float $amountLeft = null,
+        ?float $amountLeftWithoutTax = null,
+        bool $isUsageBased = false,
+    ): AppMarketPlanSubscription {
         $amountLeftArray = $this->getAmountLeft($plan->price, $tax_percentage, $amountLeft, $amountLeftWithoutTax);
 
         $trial = new Period($plan->trial_interval, $plan->trial_period - 1 , $startDate ?? now());
@@ -119,6 +131,7 @@ trait HasSubscriptions
             'starts_at' => $period->getStartDate(),
             'ends_at' => $period->getEndDate()->addDay($remainingDays),
             'purchase_id' => $purchaseId,
+            'is_usage_based' => $isUsageBased,
         ]);
     }
 
@@ -131,8 +144,21 @@ trait HasSubscriptions
      *
      * @return \Rinvex\Subscriptions\Models\AppMarketPlanSubscription
      */
-    public function newSubscriptionWithoutTrial($purchaseId, $storeUUid, $subscription, AppMarketPlan $plan, Carbon $startDate = null, $status, $isRecurring = false, $remainingDays = 0, $tax_percentage = 0.15, $activateOffer = true, ?float $amountLeft = null, ?float $amountLeftWithoutTax = null): AppMarketPlanSubscription
-    {
+    public function newSubscriptionWithoutTrial(
+        $purchaseId,
+        $storeUUid,
+        $subscription,
+        AppMarketPlan $plan,
+        Carbon $startDate = null,
+        $status,
+        $isRecurring = false,
+        $remainingDays = 0,
+        $tax_percentage = 0.15,
+        $activateOffer = true,
+        ?float $amountLeft = null,
+        ?float $amountLeftWithoutTax = null,
+        bool $isUsageBased = false,
+    ): AppMarketPlanSubscription {
         $amountLeftArray = $this->getAmountLeft($plan->price, $tax_percentage, $amountLeft, $amountLeftWithoutTax);
         $period = new Period($plan->invoice_interval, $plan->invoice_period - 1, $startDate ?? now());
 
@@ -162,6 +188,7 @@ trait HasSubscriptions
             'starts_at' => $period->getStartDate(),
             'ends_at' => $endDate,
             'purchase_id' => $purchaseId,
+            'is_usage_based' => $isUsageBased,
         ]);
     }
 

--- a/src/Traits/HasSubscriptions.php
+++ b/src/Traits/HasSubscriptions.php
@@ -129,7 +129,7 @@ trait HasSubscriptions
             'amount_left_without_tax' => $amountLeftArray[1],
             'trial_ends_at' => $trial->getEndDate(),
             'starts_at' => $period->getStartDate(),
-            'ends_at' => $period->getEndDate()->addDay($remainingDays),
+            'ends_at' => $isUsageBased ? null : $period->getEndDate()->addDay($remainingDays),
             'purchase_id' => $purchaseId,
             'is_usage_based' => $isUsageBased,
         ]);
@@ -173,7 +173,9 @@ trait HasSubscriptions
         if($planOffer && $activateOffer && $planOffer->type === 'buy_x_get_y') {
             $endDate = $endDate->addDays($planOffer->getOfferPeriod());
         }
-
+        if ($isUsageBased) {
+            $endDate = null;
+        }
         return $this->subscriptions()->create([
             'name' => $subscription,
             'uuid' => $uuid,


### PR DESCRIPTION
Add the `is_usage_based` flag to plans & subscriptions to enable the usage-based pricing model for app market plans & subscriptions.

The DB Migrations required are listed on the main PR for this feature.
https://github.com/zidsa/backend/pull/18617
Jira:
https://zid-dev.atlassian.net/browse/CR-21962